### PR TITLE
Option for other command then whatchanged

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -28,6 +28,7 @@ explicit or implied, to the extent permissible by law.
 This program might, and would be buggy. Use it at your own risk.
 """
 
+sDefaultChangeLogCommand = "whatchanged"
 sDefaultSeparator = "~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~."
 
 sDefaultFormatSpec = """

--- a/etc/gitzillarc
+++ b/etc/gitzillarc
@@ -73,6 +73,12 @@
 #      appended to '--format=format:' in 'git whatchanged'. See the
 #      'git whatchanged' manpage for more info.
 #
+#  * changelogcmd
+#      default: whatchanged
+#
+#      command which will be used for getting changelog from git
+#      another reasonable value is 'log'
+#
 #  * separator
 #
 #      default: ~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.

--- a/hooks.py
+++ b/hooks.py
@@ -7,12 +7,12 @@ hooks - git hooks provided by gitzilla.
 import re
 import sys
 from utils import get_changes, init_bugzilla, get_bug_status, notify_and_exit
-from gitzilla import sDefaultSeparator, sDefaultFormatSpec, oDefaultBugRegex
+from gitzilla import sDefaultSeparator, sDefaultFormatSpec, sDefaultChangeLogCommand, oDefaultBugRegex
 from gitzilla import NullLogger
 import traceback
 
 
-def post_receive(sBZUrl, sBZUser=None, sBZPasswd=None, sFormatSpec=None, oBugRegex=None, sSeparator=None, logger=None, bz_init=None):
+def post_receive(sBZUrl, sBZUser=None, sBZPasswd=None, sFormatSpec=None, sChangeLogCommand=None, oBugRegex=None, sSeparator=None, logger=None, bz_init=None):
   """
   a post-recieve hook handler which extracts bug ids and adds the commit
   info to the comment. If multiple bug ids are found, the comment is added
@@ -55,6 +55,9 @@ def post_receive(sBZUrl, sBZUser=None, sBZPasswd=None, sFormatSpec=None, oBugReg
   if sFormatSpec is None:
     sFormatSpec = sDefaultFormatSpec
 
+  if sChangeLogCommand is None:
+    sChangeLogCommand = sDefaultChangeLogCommand
+
   if sSeparator is None:
     sSeparator = sDefaultSeparator
 
@@ -75,7 +78,7 @@ def post_receive(sBZUrl, sBZUser=None, sBZPasswd=None, sFormatSpec=None, oBugReg
     if sPrevRev is None:
       sPrevRev = sOldRev
     logger.debug("oldrev: '%s', newrev: '%s'" % (sOldRev, sNewRev))
-    asChangeLogs = get_changes(sOldRev, sNewRev, sFormatSpec, sSeparator)
+    asChangeLogs = get_changes(sOldRev, sNewRev, sFormatSpec, sSeparator, sChangeLogCommand)
 
     for sMessage in asChangeLogs:
       logger.debug("Considering commit:\n%s" % (sMessage,))
@@ -144,6 +147,7 @@ def update(oBugRegex=None, asAllowedStatuses=None, sSeparator=None, sBZUrl=None,
     bz_init = init_bugzilla
 
   sFormatSpec = sDefaultFormatSpec
+  sChangeLogCommand = sDefaultChangeLogCommand
 
   if asAllowedStatuses is not None:
     # sanity checking
@@ -162,7 +166,7 @@ def update(oBugRegex=None, asAllowedStatuses=None, sSeparator=None, sBZUrl=None,
   (sOldRev, sNewRev) = sys.argv[2:4]
   logger.debug("oldrev: '%s', newrev: '%s'" % (sOldRev, sNewRev))
 
-  asChangeLogs = get_changes(sOldRev, sNewRev, sFormatSpec, sSeparator)
+  asChangeLogs = get_changes(sOldRev, sNewRev, sFormatSpec, sSeparator, sChangeLogCommand)
   
   for sMessage in asChangeLogs:
     logger.debug("Checking for bug refs in commit:\n%s" % (sMessage,))

--- a/hookscripts.py
+++ b/hookscripts.py
@@ -146,10 +146,12 @@ def post_receive():
   oBugRegex = get_bug_regex(siteconfig)
   sSeparator = get_or_default(siteconfig, sRepo, "separator")
   sFormatSpec = get_or_default(siteconfig, sRepo, "formatspec")
+  sChangeLogCommand = get_or_default(siteconfig, sRepo, "changelogcmd")
 
   bz_init = make_bz_init(siteconfig, bAllowDefaultAuth)
 
   gitzilla.hooks.post_receive(sBZUrl, sBZUser, sBZPasswd, sFormatSpec,
+                              sChangeLogCommand,
                               oBugRegex, sSeparator, logger, bz_init)
 
 

--- a/utils.py
+++ b/utils.py
@@ -51,7 +51,7 @@ def init_bugzilla(sBZUrl, sBZUser, sBZPasswd):
 
 
 
-def get_changes(sOldRev, sNewRev, sFormatSpec, sSeparator):
+def get_changes(sOldRev, sNewRev, sFormatSpec, sSeparator, sChangeLogCommand):
   """
   returns an array of chronological changes, between sOldRev and sNewRev,
   according to the format spec sFormatSpec.
@@ -63,7 +63,7 @@ def get_changes(sOldRev, sNewRev, sFormatSpec, sSeparator):
   else:
     sCommitRange = "%s..%s" % (sOldRev, sNewRev)
 
-  sChangeLog = execute(["git", "whatchanged",
+  sChangeLog = execute(["git", "%s" % (sChangeLogCommand),
                         "--format=format:%s%s" % (sSeparator, sFormatSpec),
                         sCommitRange])
   asChangeLogs = sChangeLog.split(sSeparator)


### PR DESCRIPTION
Hi,

I don't want to have list of changed files commited to bugzilla as we are using it also for communication with customers. Furthermore, people have access to gitweb, so the list is not really necessary. I have 'implemented' support for new config option which allows me to change whatchanged to log for example.

   Cheers,   Antonin
