### PR TITLE
prepend repository name to the update message

### DIFF
--- a/etc/gitzillarc
+++ b/etc/gitzillarc
@@ -88,6 +88,13 @@
 #      include the diffstat (a list of changed files with a histogram).
 #      If False, the diffstat is not included. True or False.
 #
+#  * include_repository_name
+#
+#      default: False
+#
+#      prepend repository name (the last component of pwd) to message
+#      If False, the name is not added. True or False.
+#
 #  * separator
 #
 #      default: ~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.~.
@@ -111,12 +118,12 @@
 #          - Bug #123
 #
 #  * git_ref_prefix
-#        
+#
 #      the string which must start a git reference for its commits to be
 #      processed. Defaults to 'refs/heads/' so that we don't process 'tags/' and
 #      run the risk of processing many commits multiple times. You can set it
 #      to the empty string to process all git references.
-#  
+#
 #  * logfile
 #
 #      the file to log to. Must be writable by the uid of the git

--- a/hooks.py
+++ b/hooks.py
@@ -6,13 +6,14 @@ hooks - git hooks provided by gitzilla.
 
 import re
 import sys
+import os
 from utils import get_changes, init_bugzilla, get_bug_status, notify_and_exit
 from gitzilla import sDefaultSeparator, sDefaultFormatSpec, oDefaultBugRegex, sDefaultRefPrefix
 from gitzilla import NullLogger
 import traceback
 
 
-def post_receive(sBZUrl, sBZUser=None, sBZPasswd=None, sFormatSpec=None, oBugRegex=None, sSeparator=None, logger=None, bz_init=None, sRefPrefix=None, bIncludeDiffStat=True, aasPushes=None):
+def post_receive(sBZUrl, sBZUser=None, sBZPasswd=None, sFormatSpec=None, oBugRegex=None, sSeparator=None, logger=None, bz_init=None, sRefPrefix=None, bIncludeDiffStat=True, aasPushes=None, bIncludeRepositoryName=False):
   """
   a post-recieve hook handler which extracts bug ids and adds the commit
   info to the comment. If multiple bug ids are found, the comment is added
@@ -98,7 +99,11 @@ def post_receive(sBZUrl, sBZUser=None, sBZPasswd=None, sFormatSpec=None, oBugReg
     logger.debug("oldrev: '%s', newrev: '%s'" % (sOldRev, sNewRev))
     asChangeLogs = get_changes(sOldRev, sNewRev, sFormatSpec, sSeparator, bIncludeDiffStat, sRefName, sRefPrefix)
 
+    (sRepoDirHead, sRepoDirTail) = os.path.split(os.getcwd())
+
     for sMessage in asChangeLogs:
+      if bIncludeRepositoryName is True:
+        sMessage = "repository  %s\n%s" % (sRepoDirTail, sMessage)
       logger.debug("Considering commit:\n%s" % (sMessage,))
       oMatch = re.search(oBugRegex, sMessage)
       if oMatch is None:

--- a/hookscripts.py
+++ b/hookscripts.py
@@ -168,12 +168,14 @@ def post_receive(aasPushes=None):
   sSeparator = get_or_default(siteconfig, sRepo, "separator")
   sFormatSpec = get_or_default(siteconfig, sRepo, "formatspec")
   bIncludeDiffStat = to_bool(get_or_default(siteconfig, sRepo, "include_diffstat", True))
+  bIncludeRepoName = to_bool(get_or_default(siteconfig, sRepo, "include_repository_name", False))
 
   bz_init = make_bz_init(siteconfig, bAllowDefaultAuth)
 
   gitzilla.hooks.post_receive(sBZUrl, sBZUser, sBZPasswd, sFormatSpec,
                               oBugRegex, sSeparator, logger, bz_init,
-                              sRefPrefix, bIncludeDiffStat, aasPushes)
+                              sRefPrefix, bIncludeDiffStat, aasPushes,
+                              bIncludeRepoName)
 
 
 


### PR DESCRIPTION
I am using gitzilla in environment with multiple repositories, so I needed the way how to add the repository name to the status message. This commit contains the initial implementation, which shows the functionality. I don't feel satisfied with the 'purity' of the code itself as it seems not to fit into your style nicely. What do you think?
